### PR TITLE
Log connection or scrape failures as errors, not debug.

### DIFF
--- a/prometheus_pgbouncer_exporter/collector.py
+++ b/prometheus_pgbouncer_exporter/collector.py
@@ -81,7 +81,7 @@ class PgbouncerMetricsCollector():
                 success = False
 
         except Exception as error:
-            logging.getLogger().debug("Unable fetch metrics from {dsn}".format(dsn=self.config.getDsnWithMaskedPassword()), extra={"exception": str(error)})
+            logging.getLogger().error("Unable fetch metrics from {dsn}".format(dsn=self.config.getDsnWithMaskedPassword()), extra={"exception": str(error)})
 
             success = False
         finally:
@@ -147,7 +147,7 @@ class PgbouncerMetricsCollector():
 
             return cursor.fetchall()
         except Exception as error:
-            logging.getLogger().debug("Unable run query {query} on {dsn}".format(query=query, dsn=self.config.getDsnWithMaskedPassword()), extra={"exception": str(error)})
+            logging.getLogger().error("Unable run query {query} on {dsn}".format(query=query, dsn=self.config.getDsnWithMaskedPassword()), extra={"exception": str(error)})
 
             return False
         finally:


### PR DESCRIPTION
Fairly straightforward.