### PR TITLE
Add PyYAML as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ psycopg2==2.7.3.2
 prometheus_client==0.0.21
 python-json-logger==0.1.5
 pycodestyle
+PyYAML==3.12


### PR DESCRIPTION
Resolves `ImportError: No module named 'yaml'` errors on a clean environment.