### PR TITLE
Add Dockerfile with minimal setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.6.6-alpine
+
+RUN apk update && \
+ apk add postgresql-libs && \
+ apk add --virtual .build-deps gcc musl-dev postgresql-dev && \
+ python3 -m pip install prometheus-pgbouncer-exporter --no-cache-dir && \
+ apk --purge del .build-deps
+
+ENV PGBOUNCER_EXPORTER_HOST="127.0.0.1" PGBOUNCER_EXPORTER_PORT=9127 \
+    PGBOUNCER_USER="pgbouncer" PGBOUNCER_PASS="" \
+    PGBOUNCER_HOST="localhost" PGBOUNCER_PORT=6543 
+EXPOSE 9127
+
+COPY config.docker.yml /etc/pgbouncer-exporter/config.yml
+
+ENTRYPOINT ["pgbouncer-exporter"]
+CMD ["--config", "/etc/pgbouncer-exporter/config.yml"]

--- a/config.docker.yml
+++ b/config.docker.yml
@@ -1,0 +1,16 @@
+# The host on which the exporter should listen to (defaults to 127.0.0.1)
+exporter_host: $(PGBOUNCER_EXPORTER_HOST)
+
+# The port on which the exporter should listen to (defaults to 9127)
+exporter_port: $(PGBOUNCER_EXPORTER_PORT)
+
+# The list of pgbouncer instances to monitor
+pgbouncers:
+  -
+    # The pgbouncer connection string. Supports environment variables replacement
+    # Ie. $(PGBOUNCER_PASS) is replaced with the content of "PGBOUNCER_PASS" environment
+    #     variable if exist, or left untouched if doesn't exist
+    dsn: postgresql://$(PGBOUNCER_USER):$(PGBOUNCER_PASS)@$(PGBOUNCER_HOST):$(PGBOUNCER_PORT)/pgbouncer
+
+    # The pgbouncer connection timeout in seconds (defaults to 5 seconds)
+    connect_timeout: 5


### PR DESCRIPTION
* Uses an Python 3.6 alpine linux image to reduce memory consumption.
* Add config.yml file with minimal configuration.
* Default port set to 9127 as it is recommended by Prometheus default port allocations (https://github.com/prometheus/prometheus/wiki/Default-port-allocations).