### PR TITLE
Fix TypeError when you try to replace default port

### DIFF
--- a/prometheus_pgbouncer_exporter/config.py
+++ b/prometheus_pgbouncer_exporter/config.py
@@ -19,7 +19,7 @@ class Config():
         return self.config["exporter_host"] if "exporter_host" in self.config else "127.0.0.1"
 
     def getExporterPort(self):
-        return self.config["exporter_port"] if "exporter_port" in self.config else 9100
+        return int(self.config["exporter_port"]) if "exporter_port" in self.config else 9100
 
     def getPgbouncers(self):
         # Lazy instance pgbouncer config


### PR DESCRIPTION
An exception occurs if you set an env var for the exporter port (`PGBOUNCER_EXPORTER_PORT=9100`).

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.6/site-packages/prometheus_client/exposition.py", line 105, in run
    httpd = ThreadingSimpleServer((addr, port), MetricsHandler)
  File "/usr/local/lib/python3.6/socketserver.py", line 453, in __init__
    self.server_bind()
  File "/usr/local/lib/python3.6/http/server.py", line 136, in server_bind
    socketserver.TCPServer.server_bind(self)
  File "/usr/local/lib/python3.6/socketserver.py", line 467, in server_bind
    self.socket.bind(self.server_address)
TypeError: an integer is required (got type str)
```

The replacer parses the yaml giving the following dict:
```
{'exporter_host': '127.0.0.1', 'exporter_port': '9128', 'pgbouncers': [{'dsn': 'postgresql://user:pass@127.0.0.1:6543/pgbouncer', 'connect_timeout': 5}]}
```

So casting the port to an int in `getExporterPort` function think that could be enough for fixing the issue.
