### PR TITLE
Feature/add configuration metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ The exporter exports the following metrics for each monitored pgbouncer instance
 | `pgbouncer_databases_database_pool_size`            | gauge    | _all_     | Configured pool size limit (labels: `database`, `backend_database`) |
 | `pgbouncer_databases_database_reserve_pool_size`    | gauge    | _all_     | Configured reserve limit (labels: `database`, `backend_database`) |
 | `pgbouncer_databases_database_current_connections`  | gauge    | _all_     | Total number of per-database Database connections count (labels: `database`, `backend_database`) |
+| `pgbouncer_databases_database_max_connections`      | gauge    | _all_     | Maximum number of allowed connections per-database (labels: `database`, `backend_database`) |
+| `pgbouncer_config_max_client_conn`                  | gauge    | _all_     | Configuration of maximum number of allowed client connections |
+| `pgbouncer_config_max_user_connections`             | gauge    | _all_     | Configuration of maximum number of server connections per user |
 
 
 ## Configuration file

--- a/prometheus_pgbouncer_exporter/collector.py
+++ b/prometheus_pgbouncer_exporter/collector.py
@@ -99,7 +99,7 @@ class PgbouncerMetricsCollector():
                     {"type": "gauge", "column": "pool_size",           "metric": "database_pool_size",           "help": "Configured Pool Size Limit"},
                     {"type": "gauge", "column": "reserve_pool",        "metric": "database_reserve_pool_size",   "help": "Configured Reserve Limit"},
                     {"type": "gauge", "column": "current_connections", "metric": "database_current_connections", "help": "Database connection count"},
-                    {"type": "gauge", "column": "max_connections",     "metric": "database_max_connections",     "help": "Database maximum number of allowed connections"},                    
+                    {"type": "gauge", "column": "max_connections",     "metric": "database_max_connections",     "help": "Database maximum number of allowed connections"},
                 ], {"name": "database", "database": "backend_database"}, self.config.getExtraLabels())
             else:
                 success = False

--- a/prometheus_pgbouncer_exporter/collector.py
+++ b/prometheus_pgbouncer_exporter/collector.py
@@ -7,7 +7,7 @@ from .config import PgbouncerConfig
 
 
 class PgbouncersMetricsCollector():
-    def __init__(self, configs: List[PgbouncerConfig]):
+    def __init__(self, configs: List[PgbouncerConfig]):        
         self.collectors = list(map(lambda config: PgbouncerMetricsCollector(config), configs))
 
     def collect(self):
@@ -99,7 +99,7 @@ class PgbouncerMetricsCollector():
                     {"type": "gauge", "column": "pool_size",           "metric": "database_pool_size",           "help": "Configured Pool Size Limit"},
                     {"type": "gauge", "column": "reserve_pool",        "metric": "database_reserve_pool_size",   "help": "Configured Reserve Limit"},
                     {"type": "gauge", "column": "current_connections", "metric": "database_current_connections", "help": "Database connection count"},
-                    {"type": "gauge", "column": "max_connections",     "metric": "database_max_connections",   "help": "Database maximum number of allowed connections"},                    
+                    {"type": "gauge", "column": "max_connections",     "metric": "database_max_connections",     "help": "Database maximum number of allowed connections"},                    
                 ], {"name": "database", "database": "backend_database"}, self.config.getExtraLabels())
             else:
                 success = False
@@ -110,7 +110,7 @@ class PgbouncerMetricsCollector():
                 metrics += self._exportKeyValueMetrics(results, "pgbouncer_config_", [
                     {"type": "gauge", "key": "max_client_conn",      "metric": "max_client_conn",      "help": "Config maximum number of client connections"},
                     {"type": "gauge", "key": "max_user_connections", "metric": "max_user_connections", "help": "Config maximum number of server connections per user"},
-                    ])
+                    ], self.config.getExtraLabels())
             else:
                 success = False
 
@@ -161,18 +161,17 @@ class PgbouncerMetricsCollector():
 
         return metrics
 
-    def _exportKeyValueMetrics(self, results, metricPrefix, metricMappings):
+    def _exportKeyValueMetrics(self, results, metricPrefix, metricMappings, extraLabels):
         metrics = []
 
         for result in results:
             for mapping in metricMappings:                
                 if (result["key"] == mapping["key"]):
-                    value = result["value"]   
-
                     metrics.append({
                         "type":   mapping["type"],
                         "name":   metricPrefix + mapping['metric'],
-                        "value":  value,                    
+                        "value":  int(result["value"]),
+                        "labels": extraLabels,                   
                         "help":   mapping["help"]
                     })
                  

--- a/prometheus_pgbouncer_exporter/collector.py
+++ b/prometheus_pgbouncer_exporter/collector.py
@@ -171,7 +171,7 @@ class PgbouncerMetricsCollector():
                         "type":   mapping["type"],
                         "name":   metricPrefix + mapping['metric'],
                         "value":  int(result["value"]),
-                        "labels": extraLabels,                   
+                        "labels": extraLabels,
                         "help":   mapping["help"]
                     })
                  

--- a/prometheus_pgbouncer_exporter/collector.py
+++ b/prometheus_pgbouncer_exporter/collector.py
@@ -174,7 +174,7 @@ class PgbouncerMetricsCollector():
                         "labels": extraLabels,
                         "help":   mapping["help"]
                     })
-                 
+
         return metrics
 
     def _filterMetricsByIncludeDatabases(self, results, databases):

--- a/prometheus_pgbouncer_exporter/collector.py
+++ b/prometheus_pgbouncer_exporter/collector.py
@@ -165,7 +165,7 @@ class PgbouncerMetricsCollector():
         metrics = []
 
         for result in results:
-            for mapping in metricMappings:                
+            for mapping in metricMappings:
                 if (result["key"] == mapping["key"]):
                     metrics.append({
                         "type":   mapping["type"],

--- a/prometheus_pgbouncer_exporter/collector.py
+++ b/prometheus_pgbouncer_exporter/collector.py
@@ -7,7 +7,7 @@ from .config import PgbouncerConfig
 
 
 class PgbouncersMetricsCollector():
-    def __init__(self, configs: List[PgbouncerConfig]):        
+    def __init__(self, configs: List[PgbouncerConfig]):
         self.collectors = list(map(lambda config: PgbouncerMetricsCollector(config), configs))
 
     def collect(self):

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -196,7 +196,7 @@ class TestPgbouncerMetricsCollector(unittest.TestCase):
         metrics = getMetricsByName(collector.collect(), "pgbouncer_config_max_user_connections")
         self.assertEqual(len(metrics), 1)
         self.assertEqual(metrics[0]["type"], "gauge")
-        self.assertEqual(metrics[0]["value"], 0)        
+        self.assertEqual(metrics[0]["value"], 0)
         
 
     def testShouldExportQueriesMetricsFromPgBouncer17(self):

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -54,7 +54,7 @@ def fetchMetricsSuccessFromPgBouncer18Mock(conn, query):
         return [
             {"key": "max_client_conn",      "value": 500, "changeable": "yes"},
             {"key": "max_user_connections", "value": 0,   "changeable": "yes"}
-        ]        
+        ]
     else:
         return False
 
@@ -197,7 +197,7 @@ class TestPgbouncerMetricsCollector(unittest.TestCase):
         self.assertEqual(len(metrics), 1)
         self.assertEqual(metrics[0]["type"], "gauge")
         self.assertEqual(metrics[0]["value"], 0)
-        
+
 
     def testShouldExportQueriesMetricsFromPgBouncer17(self):
         config = PgbouncerConfig({})

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -28,8 +28,8 @@ def fetchMetricsSuccessFromPgBouncer17Mock(conn, query):
         ]
     elif query == "SHOW CONFIG":
         return [
-            {"key": "max_client_conn","value": 500, "changeable": "yes"},
-            {"key": "max_user_connections","value": 0, "changeable": "yes"}
+            {"key": "max_client_conn",      "value": 500, "changeable": "yes"},
+            {"key": "max_user_connections", "value": 0,   "changeable": "yes"}
         ]
     else:
         return False
@@ -52,8 +52,8 @@ def fetchMetricsSuccessFromPgBouncer18Mock(conn, query):
         ]
     elif query == "SHOW CONFIG":
         return [
-            {"key": "max_client_conn","value": 500, "changeable": "yes"},
-            {"key": "max_user_connections","value": 0, "changeable": "yes"}
+            {"key": "max_client_conn",      "value": 500, "changeable": "yes"},
+            {"key": "max_user_connections", "value": 0,   "changeable": "yes"}
         ]        
     else:
         return False

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -191,7 +191,7 @@ class TestPgbouncerMetricsCollector(unittest.TestCase):
         metrics = getMetricsByName(collector.collect(), "pgbouncer_config_max_client_conn")
         self.assertEqual(len(metrics), 1)
         self.assertEqual(metrics[0]["type"], "gauge")
-        self.assertEqual(metrics[0]["value"], 500)        
+        self.assertEqual(metrics[0]["value"], 500)
 
         metrics = getMetricsByName(collector.collect(), "pgbouncer_config_max_user_connections")
         self.assertEqual(len(metrics), 1)


### PR DESCRIPTION
It is really useful to be able to compare existing metrics with allowed maximums. 
A new database metric with **max_connections** column has been added.
A new set of metrics with configuration values is now available. Current available values are **max_client_conn** and **max_user_connections**
