### PR TITLE
Bump pyyaml dependency from 5.3.1 to 5.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 2.1.2 (2021-10-08)
+
+- Upgraded dependencies
+   - `pyyaml` to 5.4.1 also changed fixed version to minimum version
+     constraint.
+
 ### 2.1.1 (2020-07-14)
 
 - Upgraded dependencies

--- a/prometheus_pgbouncer_exporter/cli.py
+++ b/prometheus_pgbouncer_exporter/cli.py
@@ -44,7 +44,7 @@ def main():
 
     # Init logger
     logHandler = logging.FileHandler(args.log_file) if args.log_file is not "stdout" else logging.StreamHandler()
-    formatter = jsonlogger.JsonFormatter("(asctime) (levelname) (message)", datefmt="%Y-%m-%d %H:%M:%S")
+    formatter = jsonlogger.JsonFormatter("%(asctime)s %(levelname)s %(message)s`", datefmt="%Y-%m-%d %H:%M:%S")
     logHandler.setFormatter(formatter)
     logging.getLogger().addHandler(logHandler)
     logging.getLogger().setLevel(args.log_level)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ psycopg2==2.8.5
 prometheus_client==0.8.0
 python-json-logger==0.1.11
 pycodestyle
-PyYAML==5.3.1
+PyYAML>=5.4.1

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.md') as file:
 setup(
   name                          = 'prometheus-pgbouncer-exporter',
   packages                      = ['prometheus_pgbouncer_exporter'],
-  version                       = '2.1.1',
+  version                       = '2.1.2',
   description                   = 'Prometheus exporter for PgBouncer',
   long_description              = long_description,
   long_description_content_type = "text/markdown",
@@ -22,7 +22,7 @@ setup(
   keywords                      = ['prometheus', 'pgbouncer'],
   classifiers                   = [],
   python_requires               = ' >= 3',
-  install_requires              = ['psycopg2 == 2.8.5', 'prometheus_client==0.8.0', 'python-json-logger==0.1.11', 'PyYAML==5.3.1'],
+  install_requires              = ['psycopg2 == 2.8.5', 'prometheus_client==0.8.0', 'python-json-logger==0.1.11', 'PyYAML>=5.4.1'],
   entry_points                  = {
     'console_scripts': [
         'pgbouncer-exporter=prometheus_pgbouncer_exporter.cli:main',


### PR DESCRIPTION
This change also makes the absolute dependency on pyyaml a minimum
version constaint for better compatibility with other pip-packages.

fixes  spreaker/prometheus-pgbouncer-exporter#39