### PR TITLE
Add avg_* metrics from SHOW STATS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,55 +1,69 @@
 # Changelog
 
+### 2.1.3 (2023-10-10)
+
+- Upgrade to Python 3.8
+- Add average metrics (avg\_\*) from SHOW STATS
+
 ### 2.1.2 (2021-10-08)
 
 - Upgraded dependencies
-   - `pyyaml` to 5.4.1 also changed fixed version to minimum version
-     constraint.
+  - `pyyaml` to 5.4.1 also changed fixed version to minimum version
+    constraint.
 
 ### 2.1.1 (2020-07-14)
 
 - Upgraded dependencies
-    - `prometheus_client` to 0.8.0
-    - `psycopg2` to 2.8.5
-    - `python-json-logger` to 0.1.11
+  - `prometheus_client` to 0.8.0
+  - `psycopg2` to 2.8.5
+  - `python-json-logger` to 0.1.11
 
 ### 2.1.0 (2020-07-10)
+
 - Upgraded PyYAML to 5.3.1 to fix CVE-2017-18342 among others
 - [FEATURE] Reload configuration file on SIGHUP. [#21](https://github.com/spreaker/prometheus-pgbouncer-exporter/pull/21) (thanks to [Vineet Joshi](https://github.com/jvineet))
 - [FEATURE] Added new metrics taken from pgbouncer configuration [#23](https://github.com/spreaker/prometheus-pgbouncer-exporter/pull/23) (thanks to [José Gabriel Duarte](https://github.com/jgduarte-stratio))
-    - `pgbouncer_databases_database_max_connections`: Maximum number of allowed connections per-database (labels: `database`, `backend_database`)
-    - `pgbouncer_config_max_client_conn`: Configuration of maximum number of allowed client connections
-    - `pgbouncer_config_max_user_connections`: Configuration of maximum number of server connections per user
+  - `pgbouncer_databases_database_max_connections`: Maximum number of allowed connections per-database (labels: `database`, `backend_database`)
+  - `pgbouncer_config_max_client_conn`: Configuration of maximum number of allowed client connections
+  - `pgbouncer_config_max_user_connections`: Configuration of maximum number of server connections per user
 
 ### 2.0.3 (2020-01-07)
+
 - Changed author of the package
 
 ### 2.0.2 (2020-01-07)
+
 - [#17](https://github.com/spreaker/prometheus-pgbouncer-exporter/pull/17) Add `maxwait_us` to the compute of `client_maxwait_seconds` metric to have a higher precission
 
 ### 2.0.1 (2018-12-11)
+
 - [BUGFIX] Correctly mask the DSN in logs when the password is empty
 
 ### 2.0.0 (2018-12-05)
+
 - [BREAKING CHANGE] Renamed `pgbouncer_stats_queries_total` to `pgbouncer_stats_requests_total` on pgbouncer <= 1.7
 - [FEATURE] Added pgbouncer >= 1.8 support [#8](https://github.com/spreaker/prometheus-pgbouncer-exporter/pull/8) (thanks to [bitglue](https://github.com/bitglue)), including the following new metrics:
-    - `pgbouncer_stats_transactions_total`
-    - `pgbouncer_stats_queries_total`
-    - `pgbouncer_stats_transactions_duration_microseconds`
-    - `pgbouncer_stats_waiting_duration_microseconds`
+  - `pgbouncer_stats_transactions_total`
+  - `pgbouncer_stats_queries_total`
+  - `pgbouncer_stats_transactions_duration_microseconds`
+  - `pgbouncer_stats_waiting_duration_microseconds`
 
 ### 1.0.1 (2018-08-30)
+
 - [BUGFIX] Fixed `PGBOUNCER_EXPORTER_PORT` environment variable data type [#7](https://github.com/spreaker/prometheus-pgbouncer-exporter/pull/7)
 
 ### 1.0.0 (2018-05-04)
+
 - [FEATURE] Added `pgbouncer_databases_database_pool_size`, `pgbouncer_databases_database_reserve_pool_size` and `pgbouncer_databases_database_current_connections` metrics [#3](https://github.com/spreaker/prometheus-pgbouncer-exporter/pull/3)
 - [BUGFIX] Fixed `PyYAML` dependency declaration [#4](https://github.com/spreaker/prometheus-pgbouncer-exporter/pull/4)
 - [BUGFIX] Ensure the exporter immediately exit on SIGTERM
 
 ### 0.2.1 (2018-02-23)
+
 - [#1](https://github.com/spreaker/prometheus-pgbouncer-exporter/pull/1) - Log connection or scrape failures as errors, not debug
 
 ### 0.2.0 (2017-12-14)
+
 - Added config file validation
 - Added `--log-file` cli argument support and handle of `kill -HUP` to re-open the log file description (useful in combination with logrotate)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.10-alpine
+FROM python:3.8-alpine
 
 RUN apk update && \
  apk add postgresql-libs && \

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.8-alpine
 
 # Install dependencies
 COPY . /prometheus-pgbouncer-exporter

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # Prometheus exporter for PgBouncer
 
-
 ## How to use it
 
 You have two options to use it:
 
 1. Manually install and run the `prometheus-pgbouncer-exporter` Python package
 2. Use the [Docker image available on Docker hub](https://hub.docker.com/r/spreaker/prometheus-pgbouncer-exporter/) (_see instructions on Docker hub_)
-
 
 ## How to manually install and run it
 
@@ -31,7 +29,6 @@ Available arguments:
                         with -HUP to re-open log file descriptor
 ```
 
-
 ## Features
 
 - [Supports multiple pgbouncer instances](#why-supporting-multiple-pgbouncer-instances)
@@ -39,41 +36,45 @@ Available arguments:
 - Allow to configure timeouts on pgbouncer connections
 - Allow to filter databases for which metrics are exported with `include_databases` and `exclude_databases`
 
-
 ### Why supporting multiple pgbouncer instances?
 
 PgBouncer is a single thread application and so can only saturate a single CPU core on high load. In high load environments, it's common practice to run multiple pgbouncer processes per machine (one for each CPU core) and load balance traffic among them. Ideally we want to run a single exporter instance per machine, capable to monitor 1+ pgbouncer(s) running on the machine itself.
-
 
 ## Exported metrics
 
 The exporter exports the following metrics for each monitored pgbouncer instance:
 
-| Metric name                                         | Type     | PgBouncer | Description      |
-| --------------------------------------------------- | -------- | --------- | ---------------- |
-| `pgbouncer_stats_requests_total`                    | counter  | _<= 1.7_  | Total number of requests pooled. Could be transactions or queries, depending on pool mode. (labels: `database`) |
-| `pgbouncer_stats_queries_total`                     | counter  | _>= 1.8_  | Total number of SQL queries pooled by pgbouncer (labels: `database`) |
-| `pgbouncer_stats_queries_duration_microseconds`     | counter  | _all_     | Total number of microseconds spent waiting for a server to return a query response. Includes time spent waiting for an available connection. (labels: `database`) |
-| `pgbouncer_stats_waiting_duration_microseconds`     | counter  | _>= 1.8_  | Total number of microseconds spent waiting for an available connection. (labels: `database`) |
-| `pgbouncer_stats_received_bytes_total`              | counter  | _all_     | Total volume in bytes of network traffic received by pgbouncer (labels: `database`) |
-| `pgbouncer_stats_sent_bytes_total`                  | counter  | _all_     | Total volume in bytes of network traffic sent by pgbouncer (labels: `database`) |
-| `pgbouncer_stats_transactions_total`                | counter  | _>= 1.8_  | Total number of SQL transactions pooled by pgbouncer (labels: `database`) |
-| `pgbouncer_stats_transactions_duration_microseconds`| counter  | _>= 1.8_  | Total number of microseconds spent in a transaction. Includes time spent waiting for an available connection. (labels: `database`) |
-| `pgbouncer_pools_client_active_connections`         | gauge    | _all_     | Client connections that are linked to server connection and can process queries (labels: `database`, `user`) |
-| `pgbouncer_pools_client_waiting_connections`        | gauge    | _all_     | Client connections have sent queries but have not yet got a server connection (labels: `database`, `user`) |
-| `pgbouncer_pools_server_active_connections`         | gauge    | _all_     | Server connections that linked to client (labels: `database`, `user`) |
-| `pgbouncer_pools_server_idle_connections`           | gauge    | _all_     | Server connections that unused and immediately usable for client queries (labels: `database`, `user`) |
-| `pgbouncer_pools_server_used_connections`           | gauge    | _all_     | Server connections that have been idle more than server_check_delay, so they needs server_check_query to run on it before it can be used (labels: `database`, `user`) |
-| `pgbouncer_pools_server_testing_connections`        | gauge    | _all_     | Server connections that are currently running either server_reset_query or server_check_query (labels: `database`, `user`) |
-| `pgbouncer_pools_server_login_connections`          | gauge    | _all_     | Server connections currently in logging in process (labels: `database`, `user`) |
-| `pgbouncer_pools_client_maxwait_seconds`            | gauge    | _all_     | How long the first (oldest) client in queue has waited, in seconds (labels: `database`, `user`) |
-| `pgbouncer_databases_database_pool_size`            | gauge    | _all_     | Configured pool size limit (labels: `database`, `backend_database`) |
-| `pgbouncer_databases_database_reserve_pool_size`    | gauge    | _all_     | Configured reserve limit (labels: `database`, `backend_database`) |
-| `pgbouncer_databases_database_current_connections`  | gauge    | _all_     | Total number of per-database Database connections count (labels: `database`, `backend_database`) |
-| `pgbouncer_databases_database_max_connections`      | gauge    | _all_     | Maximum number of allowed connections per-database (labels: `database`, `backend_database`) |
-| `pgbouncer_config_max_client_conn`                  | gauge    | _all_     | Configuration of maximum number of allowed client connections |
-| `pgbouncer_config_max_user_connections`             | gauge    | _all_     | Configuration of maximum number of server connections per user |
-
+| Metric name                                                  | Type    | PgBouncer | Description                                                                                                                                                                                               |
+| ------------------------------------------------------------ | ------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pgbouncer_stats_requests_total`                             | counter | _<= 1.7_  | Total number of requests pooled. Could be transactions or queries, depending on pool mode. (labels: `database`)                                                                                           |
+| `pgbouncer_stats_queries_total`                              | counter | _>= 1.8_  | Total number of SQL queries pooled by pgbouncer (labels: `database`)                                                                                                                                      |
+| `pgbouncer_stats_queries_duration_microseconds`              | counter | _all_     | Total number of microseconds spent waiting for a server to return a query response. Includes time spent waiting for an available connection. (labels: `database`)                                         |
+| `pgbouncer_stats_waiting_duration_microseconds`              | counter | _>= 1.8_  | Total number of microseconds spent waiting for an available connection. (labels: `database`)                                                                                                              |
+| `pgbouncer_stats_received_bytes_total`                       | counter | _all_     | Total volume in bytes of network traffic received by pgbouncer (labels: `database`)                                                                                                                       |
+| `pgbouncer_stats_sent_bytes_total`                           | counter | _all_     | Total volume in bytes of network traffic sent by pgbouncer (labels: `database`)                                                                                                                           |
+| `pgbouncer_stats_transactions_total`                         | counter | _>= 1.8_  | Total number of SQL transactions pooled by pgbouncer (labels: `database`)                                                                                                                                 |
+| `pgbouncer_stats_transactions_duration_microseconds`         | counter | _>= 1.8_  | Total number of microseconds spent in a transaction. Includes time spent waiting for an available connection. (labels: `database`)                                                                        |
+| `pgbouncer_stats_transactions_average`                       | gauge   | >=1.8     | Average transactions per second in last stat period (labels: `database`)                                                                                                                                  |
+| `pgbouncer_stats_queries_average`                            | gauge   | >=1.8     | Average queries per second in last stat period (labels: `database`)                                                                                                                                       |
+| `pgbouncer_stats_received_bytes_average`                     | gauge   | >=1.8     | Average received (from clients) bytes per second (labels: `database`)                                                                                                                                     |
+| `pgbouncer_stats_sent_bytes_average`                         | gauge   | >=1.8     | Average sent (to clients) bytes per second (labels: `database`)                                                                                                                                           |
+| `pgbouncer_stats_transactions_duration_microseconds_average` | gauge   | >=1.8     | Average transaction duration, in microseconds (labels: `database`)                                                                                                                                        |
+| `pgbouncer_stats_queries_duration_microseconds_average`      | gauge   | >=1.8     | Average query duration, in microseconds (labels: `database`)                                                                                                                                              |
+| `pgbouncer_stats_waiting_duration_microseconds_average`      | gauge   | >=1.8     | Average time spent by clients waiting for a server that were assigned a backend connection within the current stats_period, in microseconds (averaged per second within that period) (labels: `database`) |
+| `pgbouncer_pools_client_active_connections`                  | gauge   | _all_     | Client connections that are linked to server connection and can process queries (labels: `database`, `user`)                                                                                              |
+| `pgbouncer_pools_client_waiting_connections`                 | gauge   | _all_     | Client connections have sent queries but have not yet got a server connection (labels: `database`, `user`)                                                                                                |
+| `pgbouncer_pools_server_active_connections`                  | gauge   | _all_     | Server connections that linked to client (labels: `database`, `user`)                                                                                                                                     |
+| `pgbouncer_pools_server_idle_connections`                    | gauge   | _all_     | Server connections that unused and immediately usable for client queries (labels: `database`, `user`)                                                                                                     |
+| `pgbouncer_pools_server_used_connections`                    | gauge   | _all_     | Server connections that have been idle more than server\*check_delay, so they needs server_check_query to run on it before it can be used (labels: `database`, `user`)                                    |
+| `pgbouncer_pools_server_testing_connections`                 | gauge   | \_all\*   | Server connections that are currently running either server\*reset_query or server_check_query (labels: `database`, `user`)                                                                               |
+| `pgbouncer_pools_server_login_connections`                   | gauge   | \_all\*   | Server connections currently in logging in process (labels: `database`, `user`)                                                                                                                           |
+| `pgbouncer_pools_client_maxwait_seconds`                     | gauge   | _all_     | How long the first (oldest) client in queue has waited, in seconds (labels: `database`, `user`)                                                                                                           |
+| `pgbouncer_databases_database_pool_size`                     | gauge   | _all_     | Configured pool size limit (labels: `database`, `backend_database`)                                                                                                                                       |
+| `pgbouncer_databases_database_reserve_pool_size`             | gauge   | _all_     | Configured reserve limit (labels: `database`, `backend_database`)                                                                                                                                         |
+| `pgbouncer_databases_database_current_connections`           | gauge   | _all_     | Total number of per-database Database connections count (labels: `database`, `backend_database`)                                                                                                          |
+| `pgbouncer_databases_database_max_connections`               | gauge   | _all_     | Maximum number of allowed connections per-database (labels: `database`, `backend_database`)                                                                                                               |
+| `pgbouncer_config_max_client_conn`                           | gauge   | _all_     | Configuration of maximum number of allowed client connections                                                                                                                                             |
+| `pgbouncer_config_max_user_connections`                      | gauge   | _all_     | Configuration of maximum number of server connections per user                                                                                                                                            |
 
 ## Configuration file
 
@@ -88,8 +89,7 @@ exporter_port: 9100
 
 # The list of pgbouncer instances to monitor
 pgbouncers:
-  -
-    # The pgbouncer connection string. Supports environment variables replacement
+  - # The pgbouncer connection string. Supports environment variables replacement
     # Ie. $(PGBOUNCER_PASS) is replaced with the content of "PGBOUNCER_PASS" environment
     #     variable if exist, or left untouched if doesn't exist
     dsn: postgresql://pgbouncer:$(PGBOUNCER_PASS)@localhost:6431/pgbouncer
@@ -119,11 +119,9 @@ pgbouncers:
       pool_id: 2
 ```
 
-
 ### Environment variables replacement
 
 The configuration file supports environment variables replacement. If you use the syntax `$(NAME)` in any setting value, it gets replaced by the content of `NAME` environment variable or left untouched if the `NAME` environment variable does not exist.
-
 
 ## How to contribute
 
@@ -146,7 +144,6 @@ python -m prometheus_pgbouncer_exporter.cli --config ./config.yml
 pycodestyle --max-line-length=300 prometheus_pgbouncer_exporter/*.py
 ```
 
-
 ### How to publish a new version
 
 **Release python package**:
@@ -167,6 +164,7 @@ pycodestyle --max-line-length=300 prometheus_pgbouncer_exporter/*.py
    docker build -t prometheus-pgbouncer-exporter .
    ```
 3. Tag the image and push it to Docker Hub
+
    ```
    docker tag prometheus-pgbouncer-exporter spreaker/prometheus-pgbouncer-exporter:latest && \
    docker push spreaker/prometheus-pgbouncer-exporter:latest
@@ -175,8 +173,6 @@ pycodestyle --max-line-length=300 prometheus_pgbouncer_exporter/*.py
    docker push spreaker/prometheus-pgbouncer-exporter:2.0.3
    ```
 
-
 ## License
 
 This software is released under the [MIT license](LICENSE.txt).
-

--- a/prometheus_pgbouncer_exporter/cli.py
+++ b/prometheus_pgbouncer_exporter/cli.py
@@ -43,7 +43,7 @@ def main():
     args = parser.parse_args()
 
     # Init logger
-    logHandler = logging.FileHandler(args.log_file) if args.log_file is not "stdout" else logging.StreamHandler()
+    logHandler = logging.FileHandler(args.log_file) if args.log_file != "stdout" else logging.StreamHandler()
     formatter = jsonlogger.JsonFormatter("%(asctime)s %(levelname)s %(message)s`", datefmt="%Y-%m-%d %H:%M:%S")
     logHandler.setFormatter(formatter)
     logging.getLogger().addHandler(logHandler)
@@ -59,7 +59,7 @@ def main():
         sighup_received_count += 1
         logging.getLogger().info("Received SIGHUP - Incrementing HUP counter to %s",
                                  sighup_received_count)
-        if args.log_file is not "stdout":
+        if args.log_file != "stdout":
             logging.getLogger().info("Received SIGHUP - log file is closing")
             logHandler.close()
             logging.getLogger().info("Received SIGHUP - log file has been re-opened")

--- a/prometheus_pgbouncer_exporter/collector.py
+++ b/prometheus_pgbouncer_exporter/collector.py
@@ -30,9 +30,9 @@ class PgbouncersMetricsCollector():
         return metrics.values()
 
     def _instanceMetric(self, data):
-        if data["type"] is "counter":
+        if data["type"] == "counter":
             return CounterMetricFamily(data["name"], data["help"], labels=data["labels"].keys())
-        elif data["type"] is "gauge":
+        elif data["type"] == "gauge":
             return GaugeMetricFamily(data["name"], data["help"], labels=data["labels"].keys())
         else:
             raise Exception("Unsupported metric type: {type}".format(type=data['type']))
@@ -65,12 +65,18 @@ class PgbouncerMetricsCollector():
                     {"type": "counter", "column": "total_query_count", "metric": "queries_total",                      "help": "Total number of queries pooled"},
                     {"type": "counter", "column": "total_xact_time",   "metric": "transactions_duration_microseconds", "help": "Total number of microseconds spent in a transaction. Includes time spent waiting for an available connection."},
                     {"type": "counter", "column": "total_wait_time",   "metric": "waiting_duration_microseconds",      "help": "Total number of microseconds spent waiting for an available connection."},
+                    {"type": "gauge",   "column": "avg_xact_count",    "metric": "transactions_average",                       "help": "Average transactions per second in last stat period."},
+                    {"type": "gauge",   "column": "avg_query_count",   "metric": "queries_average",                            "help": "Average queries per second in last stat period."},
+                    {"type": "gauge",   "column": "avg_recv",          "metric": "received_bytes_average",                     "help": "Average received (from clients) bytes per second."},
+                    {"type": "gauge",   "column": "avg_sent",          "metric": "sent_bytes_average",                         "help": "Average sent (to clients) bytes per second."},
+                    {"type": "gauge",   "column": "avg_xact_time",     "metric": "transactions_duration_average_microseconds", "help": "Average transaction duration, in microseconds."},
+                    {"type": "gauge",   "column": "avg_query_time",    "metric": "queries_duration_average_microseconds",      "help": "Average query duration, in microseconds."},
+                    {"type": "gauge",   "column": "avg_wait_time",     "metric": "waiting_duration_average_microseconds",      "help": "Average time spent by clients waiting for a server that were assigned a backend connection within the current stats_period, in microseconds (averaged per second within that period)."},
 
                     # all versions
-                    {"type": "counter", "column": "total_query_time",  "metric": "queries_duration_microseconds",      "help": "Total number of microseconds spent waiting for a server to return a query response. Includes time spent waiting for an available connection."},
-                    {"type": "counter", "column": "total_received",    "metric": "received_bytes_total",               "help": "Total volume in bytes of network traffic received by pgbouncer"},
-                    {"type": "counter", "column": "total_sent",        "metric": "sent_bytes_total",                   "help": "Total volume in bytes of network traffic sent by pgbouncer"},
-
+                    {"type": "counter", "column": "total_query_time",  "metric": "queries_duration_microseconds",              "help": "Total number of microseconds spent waiting for a server to return a query response. Includes time spent waiting for an available connection."},
+                    {"type": "counter", "column": "total_received",    "metric": "received_bytes_total",                       "help": "Total volume in bytes of network traffic received by pgbouncer"},
+                    {"type": "counter", "column": "total_sent",        "metric": "sent_bytes_total",                           "help": "Total volume in bytes of network traffic sent by pgbouncer"},
                 ], {"database": "database"}, self.config.getExtraLabels())
             else:
                 success = False

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.md') as file:
 setup(
   name                          = 'prometheus-pgbouncer-exporter',
   packages                      = ['prometheus_pgbouncer_exporter'],
-  version                       = '2.1.2',
+  version                       = '2.1.3',
   description                   = 'Prometheus exporter for PgBouncer',
   long_description              = long_description,
   long_description_content_type = "text/markdown",

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -37,8 +37,8 @@ def fetchMetricsSuccessFromPgBouncer17Mock(conn, query):
 def fetchMetricsSuccessFromPgBouncer18Mock(conn, query):
     if query == "SHOW STATS":
         return [
-            {"database": "test", "total_query_count": 1, "total_xact_count": 2, "total_xact_time": 2, "total_wait_time": 1, "total_query_time": 2, "total_received": 3, "total_sent": 4},
-            {"database": "prod", "total_query_count": 4, "total_xact_count": 6, "total_xact_time": 3, "total_wait_time": 2, "total_query_time": 3, "total_received": 2, "total_sent": 1}
+            {"database": "test", "total_query_count": 1, "total_xact_count": 2, "total_xact_time": 2, "total_wait_time": 1, "total_query_time": 2, "total_received": 3, "total_sent": 4, "avg_xact_count": 3},
+            {"database": "prod", "total_query_count": 4, "total_xact_count": 6, "total_xact_time": 3, "total_wait_time": 2, "total_query_time": 3, "total_received": 2, "total_sent": 1, "avg_xact_count": 4}
         ]
     elif query == "SHOW POOLS":
         return [
@@ -318,6 +318,15 @@ class TestPgbouncerMetricsCollector(unittest.TestCase):
 
         metrics = getMetricsByName(collector.collect(), "pgbouncer_stats_requests_total")
         self.assertEqual(len(metrics), 0)
+
+        metrics = getMetricsByName(collector.collect(), "pgbouncer_stats_transactions_average")
+        self.assertEqual(len(metrics), 2)
+        self.assertEqual(metrics[0]["type"], "gauge")
+        self.assertEqual(metrics[0]["value"], 3)
+        self.assertEqual(metrics[0]["labels"], {"database":"test"})
+        self.assertEqual(metrics[1]["type"], "gauge")
+        self.assertEqual(metrics[1]["value"], 4)
+        self.assertEqual(metrics[1]["labels"], {"database":"prod"})
 
     #
     # Databases filtering


### PR DESCRIPTION
This PR adds additional metrics exposed by SHOW STATS:

- avg_xact_count
- avg_query_count
- avg_recv
- avg_sent
- avg_xact_time
- avg_query_time
- avg_wait_time

Also, upgrade to Python 3.8 and couple of cosmetic changes made by VScode plugins.