### PR TITLE
Allow filtering out metrics for pools with no connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ pgbouncers:
     extra_labels:
       pool_id: 1
 
+    # Omit metrics for pools for which PgBouncer has no client or server
+    # connections open. Recommended if you have a lot of different database
+    # users, because PgBouncer never forgets about users it has seen.
+    # If omitted, no filtering is done.
+    filter_empty_pools: true
+
   - dsn: postgresql://pgbouncer:$(PGBOUNCER_PASS)@localhost:6432/pgbouncer
     exclude_databases:
       - pgbouncer

--- a/prometheus_pgbouncer_exporter/collector.py
+++ b/prometheus_pgbouncer_exporter/collector.py
@@ -80,6 +80,7 @@ class PgbouncerMetricsCollector():
             if results:
                 results = self._filterMetricsByIncludeDatabases(results, self.config.getIncludeDatabases())
                 results = self._filterMetricsByExcludeDatabases(results, self.config.getExcludeDatabases())
+                results = self._filterEmptyPools(results)
                 metrics += self._exportMetrics(results, "pgbouncer_pools_", [
                     {"type": "gauge", "column": "cl_active",              "metric": "client_active_connections",   "help": "Client connections that are linked to server connection and can process queries"},
                     {"type": "gauge", "column": "cl_waiting",             "metric": "client_waiting_connections",  "help": "Client connections have sent queries but have not yet got a server connection"},
@@ -193,6 +194,25 @@ class PgbouncerMetricsCollector():
             return results
 
         return filter(lambda item: item["database"] not in databases, results)
+
+    def _filterEmptyPools(self, results):
+        # Filter out pools that have no client or server connections.
+        return filter(
+            lambda item: sum(
+                item[x]
+                for x in [
+                    "cl_active",
+                    "cl_waiting",
+                    "sv_active",
+                    "sv_idle",
+                    "sv_used",
+                    "sv_tested",
+                    "sv_login",
+                ]
+            )
+            > 0,
+            results,
+        )
 
     def _fetchMetrics(self, conn, query):
         cursor = False

--- a/prometheus_pgbouncer_exporter/collector.py
+++ b/prometheus_pgbouncer_exporter/collector.py
@@ -185,14 +185,14 @@ class PgbouncerMetricsCollector():
         if not databases:
             return results
 
-        return list(filter(lambda item: item["database"] in databases, results))
+        return filter(lambda item: item["database"] in databases, results)
 
     def _filterMetricsByExcludeDatabases(self, results, databases):
         # No filtering if empty
         if not databases:
             return results
 
-        return list(filter(lambda item: item["database"] not in databases, results))
+        return filter(lambda item: item["database"] not in databases, results)
 
     def _fetchMetrics(self, conn, query):
         cursor = False

--- a/prometheus_pgbouncer_exporter/collector.py
+++ b/prometheus_pgbouncer_exporter/collector.py
@@ -30,9 +30,9 @@ class PgbouncersMetricsCollector():
         return metrics.values()
 
     def _instanceMetric(self, data):
-        if data["type"] is "counter":
+        if data["type"] == "counter":
             return CounterMetricFamily(data["name"], data["help"], labels=data["labels"].keys())
-        elif data["type"] is "gauge":
+        elif data["type"] == "gauge":
             return GaugeMetricFamily(data["name"], data["help"], labels=data["labels"].keys())
         else:
             raise Exception("Unsupported metric type: {type}".format(type=data['type']))

--- a/prometheus_pgbouncer_exporter/collector.py
+++ b/prometheus_pgbouncer_exporter/collector.py
@@ -80,7 +80,8 @@ class PgbouncerMetricsCollector():
             if results:
                 results = self._filterMetricsByIncludeDatabases(results, self.config.getIncludeDatabases())
                 results = self._filterMetricsByExcludeDatabases(results, self.config.getExcludeDatabases())
-                results = self._filterEmptyPools(results)
+                if self.config.getFilterEmptyPools():
+                    results = self._filterEmptyPools(results)
                 metrics += self._exportMetrics(results, "pgbouncer_pools_", [
                     {"type": "gauge", "column": "cl_active",              "metric": "client_active_connections",   "help": "Client connections that are linked to server connection and can process queries"},
                     {"type": "gauge", "column": "cl_waiting",             "metric": "client_waiting_connections",  "help": "Client connections have sent queries but have not yet got a server connection"},

--- a/prometheus_pgbouncer_exporter/config.py
+++ b/prometheus_pgbouncer_exporter/config.py
@@ -105,6 +105,9 @@ class PgbouncerConfig():
     def getExcludeDatabases(self):
         return self.config["exclude_databases"] if "exclude_databases" in self.config else []
 
+    def getFilterEmptyPools(self):
+        return self.config.get("filter_empty_pools", False)
+
     def getExtraLabels(self):
         # Lazy instance extra labels
         if self.labels is False:


### PR DESCRIPTION
This PR adds a new config option `filter_empty_pools`. When enabled, this option causes the exporter to not emit pool metrics for pools with no active connections (all values zero).

This filtering is useful when you use PgBouncer with temporary database users: currently PgBouncer will never "forget" a user and keep reporting an empty pool for each user it has ever seen (https://github.com/pgbouncer/pgbouncer/issues/1085).
Enabling this filtering speeds up metric collection and (for us) greatly reduces the amount of emitted metrics.

The new config option is added to the README and has a unit test to verify it works as described.

This PR also contains two other changes:

- Fixes a SyntaxWarning related to comparing strings using `is` by using `==` instead.
- Slightly speeds up metrics filtering by making `_filterMetricsByIncludeDatabases` and `_filterMetricsByExcludeDatabases` return generators instead of lists.
  This way the exporter needs to loop over the results only once (when actually generating metrics), instead of once for every filter that's enabled.