### PR TITLE
fix(docker_compose): remove obsolete "version" parameter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   dev:
     build:


### PR DESCRIPTION
When running `docker-compose` it warns that this parameter is now ignored, so it should be removed:

```% docker-compose build && docker-compose run dev

WARN[0000] /Users/gclough/Documents/GitHub/prometheus-pgbouncer-exporter/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
[+] Building 0/0
[+] Building 0/1Building                                                                                                                                                                                                                                                                                                                                    0.1s 
[+] Building 12.4s (11/11) FINISHED                                                                                                                                                                                                                                                                                                         docker:desktop-linux 
...
````