### PR TITLE
Upgrade to python 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine
+FROM python:3.9-alpine
 
 RUN apk update && \
  apk add postgresql-libs && \

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine
+FROM python:3.9-alpine
 
 # Install dependencies
 COPY . /prometheus-pgbouncer-exporter


### PR DESCRIPTION
Python 3.8 is EOL as of October 7, 2024. 

This also remediates a vulnerability with libxml2 version 2.12.7-r2 which was being pulled in by the current Python 3.8 Dockerfile-dev on `master`.